### PR TITLE
Contact lookup improvements

### DIFF
--- a/callmonitor.html
+++ b/callmonitor.html
@@ -32,3 +32,35 @@
     <input type="text" id="node-input-topic" />
   </div>
 </script>
+
+<script type="text/x-red" data-help-name="fritzbox-callmonitor">
+<p>Get notified about incoming/outgoing/missed calls.</p>
+
+<h3>Outputs</h3>
+<dl class="message-properties">
+  <dt>payload.type
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Event type: INBOUND/MISSED, OUTBOUND/UNREACHED, CONNECT/DISCONNECT</dd>
+  <dt>payload.caller
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Number of the caller.</dd>
+  <dt>payload.callee
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Number of the callee.</dd>
+  <dt>payload.extension
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Extension for the call. (Only for outgoing calls.)</dd>
+  <dt>payload.id
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Call id</dd>
+  <dt>payload.timestamp
+    <span class="property-type">string</span>
+  </dt>
+  <dd>Timestamp of the event</dd>
+</dl>
+</script>

--- a/contact.html
+++ b/contact.html
@@ -67,18 +67,19 @@
 <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>payload
-            <span class="property-type">string</span>
+            <span class="property-type">string / object</span>
         </dt>
-        <dd> the phonenumber to search for. </dd>
+        <dd>Either a phonenumber to search for or the JSON output of the FRITZ!Box Callmonitor.</dd>
     </dl>
 
  <h3>Outputs</h3>
    <dl class="message-properties">
        <dt>payload <span class="property-type">json array</span></dt>
-       <dd>the contacts matching the number.</dd>
+       <dd>The contacts matching the phonenumber or the JSON output of the FRITZ!Box Callmonitor enriched with contacts for caller and callee.</dd>
    </dl>
 
 <h3>Details</h3>
-    Provide the phonenumber for which you want to do a reverse lookup in your phonebook as <p><code>msg.payload</code>.
-    It will return a JSON Array with all matching contacts.</p>
+    <p>Provide the phonenumber for which you want to do a reverse lookup in your phonebook as <code>msg.payload</code>.
+    It will return a JSON Array with all matching contacts. In addition the node can be directly connected to the
+    FRITZ!Box Callmonitor node and will enhance its output with the matching contacts for caller and callee.</p>
 </script>

--- a/contact.js
+++ b/contact.js
@@ -1,9 +1,9 @@
 var request = require("request");
 var parser = require("xml2js").Parser({explicitRoot: false, explicitArray: false, mergeAttrs: true});
 var Promise = require("bluebird");
- var PNU = require('google-libphonenumber').PhoneNumberUtil;
- var PNF = require('google-libphonenumber').PhoneNumberFormat;
- var phoneUtil = PNU.getInstance();
+var PNU = require('google-libphonenumber').PhoneNumberUtil;
+var PNF = require('google-libphonenumber').PhoneNumberFormat;
+var phoneUtil = PNU.getInstance();
 
 module.exports = function(RED) {
 
@@ -11,13 +11,13 @@ module.exports = function(RED) {
     res.end(JSON.stringify(phoneUtil.getSupportedRegions()));
   });
 
-	function FritzBoxContact(n) {
-		RED.nodes.createNode(this,n);
-		var node = this;
+  function FritzBoxContact(n) {
+    RED.nodes.createNode(this,n);
+    var node = this;
     node.topic = n.topic;
     node.phonebook = n.phonebook || 0;
     node.ccode = n.ccode;
-		node.config = RED.nodes.getNode(n.device);
+    node.config = RED.nodes.getNode(n.device);
 
     var statusupdate = function(status) {
       node.status = status;
@@ -39,7 +39,7 @@ module.exports = function(RED) {
             return Promise.promisify(request, {multiArgs: true})({uri: url.NewPhonebookURL, rejectUnauthorized: false});
           }).then(function(result) {
             var body = result[1];
-						return Promise.promisify(parser.parseString)(body);
+            return Promise.promisify(parser.parseString)(body);
           }).then(function(result) {
             msg.payload = [];
             result.phonebook.contact.forEach(function(contact) {
@@ -70,11 +70,10 @@ module.exports = function(RED) {
     });
 
     node.on('close', function() {
-			node.config.removeListener('statusUpdate', statusupdate);
+      node.config.removeListener('statusUpdate', statusupdate);
     });
 
-
-	}
-	RED.nodes.registerType("fritzbox-contact", FritzBoxContact);
+  }
+  RED.nodes.registerType("fritzbox-contact", FritzBoxContact);
 
 };


### PR DESCRIPTION
@mapero Thanks for creating these nodes 👍 

I'm using the project to receive notifications about missed call on my mobile phone. While the callmonitor was pretty easy to use, I found it fairly complicated to get the contact lookup done so that it would notify me with name and number if a contact existed in the phonebook and with the number only if not. The main issue I had was that the lookup node interrupted the flow if a number was empty (unknown caller) or if a lookup failed.

In order to make things easier for users, I modified the lookup node, so that it wouldn't interrupt the flow on error, but simply return an empty array. Additionally it's now possible to connect the callmonitor node as input and have the lookup node enrich its data with `caller_contacts` and `callee_contacts` fields.

Would be great to get this merged and released in the next version. Let me know if you want me to change something.