### PR TITLE
Make Callmonitor TCP connection more robust

### DIFF
--- a/callmonitor.js
+++ b/callmonitor.js
@@ -9,7 +9,7 @@ module.exports = function(RED) {
 		node.config = RED.nodes.getNode(n.device);
 
     var client = new net.Socket();
-		client.setKeepAlive(true, 118000);
+    client.setKeepAlive(true, 118000);
     var connections = {};
     var timeout;
     var options = {

--- a/callmonitor.js
+++ b/callmonitor.js
@@ -9,6 +9,7 @@ module.exports = function(RED) {
 		node.config = RED.nodes.getNode(n.device);
 
     var client = new net.Socket();
+		client.setKeepAlive(true, 118000);
     var connections = {};
     var timeout;
     var options = {


### PR DESCRIPTION
Enabling keep-alives to help in situations where Fritzbox is NAT'ted and/or firewalled.
Some network setups unstateful close a TCP connection if it has been idle for a certain period of time. This results in the client not knowing that the connection has been closed, and therefore not reconnecting.