### PR TITLE
Include call duration information in payload

### DIFF
--- a/callmonitor.js
+++ b/callmonitor.js
@@ -91,6 +91,7 @@ module.exports = function(RED) {
           connections[id] = message;
           break;
         case "DISCONNECT":
+          message.duration = array[3];
           switch(message.type) {
             case "INBOUND":
               message.type = "MISSED";


### PR DESCRIPTION
One line is all it needs to add call duration information to the call monitor node's output.